### PR TITLE
added a hint for java version to avoid errors

### DIFF
--- a/ear/pom.xml
+++ b/ear/pom.xml
@@ -56,5 +56,8 @@
             </plugin>
         </plugins>
     </build>
-
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
 </project>


### PR DESCRIPTION
There is a java 8 ism in the source and it wouldn’t compile out of the
box until I updated the java source version